### PR TITLE
autofix.ci integration test

### DIFF
--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -1,9 +1,14 @@
 [
   {
-    "id": "achievement_kill_zombie",
+    "id": 
+      "achievement_kill_zombie",
     "type": "achievement",
-    "name": { "str": "[Combat] One Down, Billions to Go\u2026" },
-    "kill_requirements": [ { "species": "ZOMBIE", "is": ">=", "count": 1 } ],
+    "name": { 
+        "str": "[Combat] One Down, Billions to Go\u2026" 
+},
+    "kill_requirements":
+      [ { "species": "ZOMBIE", "is": ">=", "count": 1 } 
+  ],
     "requirements": [ { "event_statistic": "num_avatar_zombie_kills", "is": "anything" } ]
   },
   {
@@ -22,6 +27,14 @@
     "kill_requirements": [ { "is": ">=", "count": 1 } ],
     "requirements": [ { "event_statistic": "num_avatar_kills", "is": "anything" } ]
   },
+    {
+    "id": "achievement_kill_in_first_ten_second",
+      "type": "achievement",
+    "name": { "str": "[Combat] Ruder Awakening" },
+    "time_constraint": { "since": "game_start", "is": "<=", "target": "10 second" },
+    "kill_requirements": [ { "is": ">=", "count": 1 } ],
+    "requirements": [{"event_statistic": "num_avatar_kills", "is": "anything"}]
+     },
   {
     "id": "achievement_kill_pacifist",
     "type": "achievement",

--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -1,14 +1,9 @@
 [
   {
-    "id": 
-      "achievement_kill_zombie",
+    "id": "achievement_kill_zombie",
     "type": "achievement",
-    "name": { 
-        "str": "[Combat] One Down, Billions to Go\u2026" 
-},
-    "kill_requirements":
-      [ { "species": "ZOMBIE", "is": ">=", "count": 1 } 
-  ],
+    "name": { "str": "[Combat] One Down, Billions to Go\u2026" },
+    "kill_requirements": [ { "species": "ZOMBIE", "is": ">=", "count": 1 } ],
     "requirements": [ { "event_statistic": "num_avatar_zombie_kills", "is": "anything" } ]
   },
   {
@@ -27,14 +22,14 @@
     "kill_requirements": [ { "is": ">=", "count": 1 } ],
     "requirements": [ { "event_statistic": "num_avatar_kills", "is": "anything" } ]
   },
-    {
+  {
     "id": "achievement_kill_in_first_ten_second",
-      "type": "achievement",
+    "type": "achievement",
     "name": { "str": "[Combat] Ruder Awakening" },
     "time_constraint": { "since": "game_start", "is": "<=", "target": "10 second" },
     "kill_requirements": [ { "is": ">=", "count": 1 } ],
-    "requirements": [{"event_statistic": "num_avatar_kills", "is": "anything"}]
-     },
+    "requirements": [ { "event_statistic": "num_avatar_kills", "is": "anything" } ]
+  },
   {
     "id": "achievement_kill_pacifist",
     "type": "achievement",


### PR DESCRIPTION
## Previous attempts

### Fails

- https://github.com/scarf-roguelike/Cataclysm-BN/pull/1 (used `pull_request_target`)
- https://github.com/scarf-roguelike/Cataclysm-BN/pull/2 (forgot to add 'always run' since JSON formatter always fail on formatting)
- https://github.com/scarf005/Cataclysm-BN/pull/17 (hand slipped and opened PR to same repo)

### Partial Success
- https://github.com/scarf-roguelike/Cataclysm-BN/pull/3 (forgot to set `commit-message` to be [conventional](conventionalcommits.org/))

## Workflow

https://github.com/scarf-roguelike/Cataclysm-BN/commit/9de45f64eebd89991f8f82a2924c9dddfb565337

## See it in action

### commit made by <autofix.ci>

![image](https://github.com/scarf-roguelike/Cataclysm-BN/assets/54838975/c9db8bf6-3d4f-4d94-a9b8-337b57e3d388)

### commit history

![image](https://github.com/scarf-roguelike/Cataclysm-BN/assets/54838975/2344df8e-f66f-4c21-b7e6-8c5a54beea63)

https://github.com/scarf-roguelike/Cataclysm-BN/pull/4/files/f7c5dba1f9e10fef1d3c95641257b8b57bca547d..4725cc5df751c8f34eb96eaf0fb37f66dec12214
